### PR TITLE
update wordpress subscription manifest

### DIFF
--- a/apps/wordpress-app.yaml
+++ b/apps/wordpress-app.yaml
@@ -45,23 +45,24 @@ spec:
   packageOverrides:
   - packageName: kustomization
     packageOverrides:
-    - resources:
-      - wordpress
-      - mysql
-      patchesStrategicMerge:
-      - patch.yaml
-      namePrefix: demo-
-      vars:
-      - name: WORDPRESS_SERVICE
-        objref:
-          kind: Service
-          name: wordpress
-          apiVersion: v1
-      - name: MYSQL_SERVICE
-        objref:
-          kind: Service
-          name: mysql
-          apiVersion: v1
+    - value:
+        resources:
+        - wordpress
+        - mysql
+        patchesStrategicMerge:
+        - patch.yaml
+        namePrefix: demo-
+        vars:
+          - name: WORDPRESS_SERVICE
+            objref:
+              kind: Service
+              name: wordpress
+              apiVersion: v1
+          - name: MYSQL_SERVICE
+            objref:
+              kind: Service
+              name: mysql
+              apiVersion: v1
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy


### PR DESCRIPTION
* pods where not getting created
* with the change, pods will get created, but wordpress will fail due to deployment yaml, fail to initContainer
* this can be used as negative example